### PR TITLE
removed arg montage from mne.create_info

### DIFF
--- a/hypyp/utils.py
+++ b/hypyp/utils.py
@@ -232,8 +232,8 @@ def split(raw_merge: mne.io.Raw) -> mne.io.Raw:
     data_S2 = raw_merge.get_data(picks=ch_S2)
 
     # creating info for raws
-    info = mne.create_info(ch, raw_merge.info['sfreq'], ch_types='eeg',
-                           montage=None, verbose=None)
+    info = mne.create_info(ch, raw_merge.info['sfreq'], ch_types='eeg', verbose=None)
+
     raw_S1 = mne.io.RawArray(data_S1, info)
     raw_S2 = mne.io.RawArray(data_S2, info)
 


### PR DESCRIPTION
### Remove argument 'montage' from [`mne.create_info()`](https://mne.tools/stable/generated/mne.create_info.html?highlight=mne%20create_info#) in `hypyp.utils.split()`

When running hypyp.utils.split(), python throws the following TypeError:

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
/var/folders/vv/stc9rswn5c95vxdzpx7z6qqr0000gn/T/ipykernel_72933/3362665754.py in <module>
----> 1 raw_S1, raw_S2 = hypyp.utils.split(raw)

~/opt/anaconda3/lib/python3.8/site-packages/hypyp/utils.py in split(raw_merge)
    233 
    234     # creating info for raws
--> 235     info = mne.create_info(ch, raw_merge.info['sfreq'], ch_types='eeg',
    236                            montage=None, verbose=None)
    237     raw_S1 = mne.io.RawArray(data_S1, info)

TypeError: create_info() got an unexpected keyword argument 'montage'

```

When verifying the MNE documentation ([0.24.1 (current)](https://mne.tools/stable/generated/mne.create_info.html?highlight=mne%20create_info#), [0.23.1](https://mne.tools/0.23/generated/mne.create_info.html?highlight=create_info#mne.create_info), [0.22.1](https://mne.tools/0.22/generated/mne.create_info.html?highlight=mne%20create_info#mne.create_info), and [0.21.1](https://mne.tools/0.21/generated/mne.create_info.html?highlight=create_info#mne.create_info)) for `create_info()`, no 'montage' argument can be found.

**This pull request proposes to remove that argument from the `mne.create_info()` within `hypyp.utils.split()`.**